### PR TITLE
fix for memory leak

### DIFF
--- a/ipi/engine/forcefields.py
+++ b/ipi/engine/forcefields.py
@@ -60,7 +60,7 @@ class ForceField(dobject):
         _threadlock: Python handle used to lock the thread held in _thread.
     """
 
-    def __init__(self, latency=1.0, name="", pars=None, dopbc=True):
+    def __init__(self, latency=1.0, name="", pars=None, dopbc=True, iobj=None):
         """Initialises ForceField.
 
         Args:
@@ -85,6 +85,7 @@ class ForceField(dobject):
         self._thread = None
         self._doloop = [False]
         self._threadlock = threading.Lock()
+        self.iobj = iobj
 
     def queue(self, atoms, cell, reqid=-1):
         """Adds a request.
@@ -231,7 +232,7 @@ class FFSocket(ForceField):
             communication between the forcefield and the driver is done.
     """
 
-    def __init__(self, latency=1.0, name="", pars=None, dopbc=True, interface=None):
+    def __init__(self, latency=1.0, name="", pars=None, dopbc=True, interface=None, iobj=None):
         """Initialises FFSocket.
 
         Args:
@@ -247,7 +248,7 @@ class FFSocket(ForceField):
         """
 
         # a socket to the communication library is created or linked
-        super(FFSocket, self).__init__(latency, name, pars, dopbc)
+        super(FFSocket, self).__init__(latency, name, pars, dopbc, iobj)
         if interface is None:
             self.socket = InterfaceSocket()
         else:
@@ -291,7 +292,7 @@ class FFLennardJones(ForceField):
                          'start': starting time}.
     """
 
-    def __init__(self, latency=1.0e-3, name="", pars=None, dopbc=False):
+    def __init__(self, latency=1.0e-3, name="", pars=None, dopbc=False, iobj=None):
         """Initialises FFLennardJones.
 
         Args:
@@ -303,7 +304,7 @@ class FFLennardJones(ForceField):
             raise ValueError("Periodic boundary conditions are not supported by FFLennardJones.")
 
         # a socket to the communication library is created or linked
-        super(FFLennardJones, self).__init__(latency, name, pars, dopbc=False)
+        super(FFLennardJones, self).__init__(latency, name, pars, dopbc=False, iobj=iobj)
         self.epsfour = float(self.pars["eps"]) * 4
         self.sixepsfour = 6 * self.epsfour
         self.sigma2 = float(self.pars["sigma"]) * float(self.pars["sigma"])
@@ -353,7 +354,7 @@ class FFLennardJones(ForceField):
 class FFDebye(ForceField):
    """Debye crystal harmonic reference potential
 
-   Computes a harmonic forcefield. 
+   Computes a harmonic forcefield.
 
    Attributes:
       parameters: A dictionary of the parameters used by the driver. Of the
@@ -364,8 +365,8 @@ class FFDebye(ForceField):
                       'status': status, 'result': result, 'id': bead id,
                       'start': starting time}.
    """
-   
-   def __init__(self, latency = 1.0, name = "",  H=None, xref=None, vref=0.0, pars=None, dopbc = False, threaded=True):
+
+   def __init__(self, latency = 1.0, name = "",  H=None, xref=None, vref=0.0, pars=None, dopbc = False, threaded=True, iobj=None):
       """Initialises FFDebye.
 
       Args:
@@ -374,19 +375,19 @@ class FFDebye(ForceField):
 
       # a socket to the communication library is created or linked
       # NEVER DO PBC -- forces here are computed without.
-      super(FFDebye,self).__init__(latency, name, pars, dopbc=False)
-            
+      super(FFDebye,self).__init__(latency, name, pars, dopbc=False, iobj=iobj)
+
       if H is None:
           raise ValueError("Must provide a dynamical matrix for the Debye crystal.")
       if xref is None:
           raise ValueError("Must provide a reference configuration for the Debye crystal.")
-  		  
+
       self.H = H
       self.xref = xref
       self.vref = vref
 
-      eigsys=np.linalg.eigh(self.H) 
-      info(" @ForceField: Hamiltonian eigenvalues: " + ' '.join(map(str, eigsys[0])), verbosity.medium)                 
+      eigsys=np.linalg.eigh(self.H)
+      info(" @ForceField: Hamiltonian eigenvalues: " + ' '.join(map(str, eigsys[0])), verbosity.medium)
 
    def poll(self):
       """ Polls the forcefield checking if there are requests that should
@@ -408,14 +409,14 @@ class FFDebye(ForceField):
 
       q = r["pos"]
       n3 = len(q)
-      if self.H.shape != (n3,n3): 
+      if self.H.shape != (n3,n3):
           raise ValueError("Hessian size mismatch")
-      if self.xref.shape != (n3,): 
+      if self.xref.shape != (n3,):
           raise ValueError("Reference structure size mismatch")
-      
+
       d = q-self.xref
       mf = np.dot(self.H, d)
-            
+
       r["result"] = [ self.vref + 0.5*np.dot(d,mf), -mf, np.zeros((3,3),float), ""]
       r["status"] = "Done"
       r["t_finished"] = time.time()

--- a/ipi/engine/system.py
+++ b/ipi/engine/system.py
@@ -54,7 +54,7 @@ class System(dobject):
       simul: The parent simulation object.
    """
 
-   def __init__(self, init, beads, nm, cell, fcomponents, bcomponents=[], ensemble=None, motion=None, prefix=""):
+   def __init__(self, init, beads, nm, cell, fcomponents, bcomponents=[], ensemble=None, motion=None, prefix="", iobj=None):
       """Initialises System class.
 
       Args:
@@ -80,6 +80,7 @@ class System(dobject):
       self.beads = beads
       self.cell = cell
       self.nm = nm
+      self.iobj = iobj
 
       self.fcomp = fcomponents
       self.forces = Forces()
@@ -103,9 +104,9 @@ class System(dobject):
       self.ensemble.bind(self.beads, self.nm, self.cell, self.forces, self.bias)
       self.motion.bind(self.ensemble, self.beads, self.nm, self.cell, self.forces, self.prng)
 
-         
+
       dpipe(dd(self.nm).omegan2, dd(self.forces).omegan2)
-      
+
       self.init.init_stage2(self)
 
       # binds output management objects

--- a/ipi/inputs/forcefields.py
+++ b/ipi/inputs/forcefields.py
@@ -75,7 +75,7 @@ class InputForceField(Input):
 
       super(InputForceField,self).fetch()
 
-      return ForceField(pars = self.parameters.fetch(), name = self.name.fetch(), latency = self.latency.fetch(), dopbc = self.pbc.fetch())
+      return ForceField(pars = self.parameters.fetch(), name = self.name.fetch(), latency = self.latency.fetch(), dopbc = self.pbc.fetch(), iobj=self)
 
 
 class InputFFSocket(InputForceField):
@@ -147,9 +147,14 @@ class InputFFSocket(InputForceField):
          A ForceSocket object with the correct socket parameters.
       """
 
-      return FFSocket(pars = self.parameters.fetch(), name = self.name.fetch(), latency = self.latency.fetch(), dopbc = self.pbc.fetch(),
-              interface=InterfaceSocket(address=self.address.fetch(), port=self.port.fetch(),
-            slots=self.slots.fetch(), mode=self.mode.fetch(), timeout=self.timeout.fetch() ) )
+      return FFSocket(pars=self.parameters.fetch(), name=self.name.fetch(),
+                      latency=self.latency.fetch(), dopbc=self.pbc.fetch(),
+                      interface=InterfaceSocket(address=self.address.fetch(),
+                                                port=self.port.fetch(),
+                                                slots=self.slots.fetch(),
+                                                mode=self.mode.fetch(),
+                                                timeout=self.timeout.fetch()),
+                      iobj=self)
 
 
    def check(self):
@@ -184,26 +189,29 @@ class InputFFLennardJones(InputForceField):
    def fetch(self):
       super(InputFFLennardJones,self).fetch()
 
-      return FFLennardJones(pars = self.parameters.fetch(), name = self.name.fetch(),
-               latency = self.latency.fetch(), dopbc = self.pbc.fetch())
+      return FFLennardJones(pars=self.parameters.fetch(),
+                            name=self.name.fetch(),
+                            latency=self.latency.fetch(),
+                            dopbc=self.pbc.fetch(),
+                            iobj=self)
 
 
 class InputFFDebye(InputForceField):
 
-   fields = { 
-   "hessian" : (InputArray, {"dtype": float, "default"      : input_default(factory=np.zeros, args=(0,)), "help": "Specifies the Hessian of the harmonic potential (atomic units!)"} ), 
+   fields = {
+   "hessian" : (InputArray, {"dtype": float, "default"      : input_default(factory=np.zeros, args=(0,)), "help": "Specifies the Hessian of the harmonic potential (atomic units!)"} ),
    "x_reference" : (InputArray, {"dtype": float, "default"  : input_default(factory=np.zeros, args=(0,)), "help": "Minimum-energy configuration for the harmonic potential", "dimension" : "length"} ),
    "v_reference" : (InputValue, {"dtype": float, "default"  : 0.0, "help": "Zero-value of energy for the harmonic potential", "dimension":"energy"})
    }
-   
+
    fields.update(InputForceField.fields)
-   
+
    attribs = {}
    attribs.update(InputForceField.attribs)
-   
+
    default_help = """Harmonic energy calculator """
    default_label = "FFDEBYE"
-	  
+
    def store(self, ff):
       super(InputFFDebye,self).store(ff)
       self.hessian.store(ff.H)
@@ -213,5 +221,7 @@ class InputFFDebye(InputForceField):
    def fetch(self):
       super(InputFFDebye,self).fetch()
 
-      return FFDebye(H=self.hessian.fetch(), xref=self.x_reference.fetch(), vref=self.v_reference.fetch(), name = self.name.fetch(),
-               latency = self.latency.fetch(), dopbc = self.pbc.fetch() )
+      return FFDebye(H=self.hessian.fetch(), xref=self.x_reference.fetch(),
+                     vref=self.v_reference.fetch(), name=self.name.fetch(),
+                     latency=self.latency.fetch(), dopbc=self.pbc.fetch(),
+                     iobj=self)

--- a/ipi/inputs/simulation.py
+++ b/ipi/inputs/simulation.py
@@ -135,21 +135,21 @@ class InputSimulation(Input):
       for fname in simul.fflist:
          ff=simul.fflist[fname]
          if type(ff) is eforcefields.FFSocket:
-            iff = iforcefields.InputFFSocket()
+            iff = ff.iobj
             iff.store(ff)
             self.extra.append(("ffsocket",iff))
          elif type(ff) is eforcefields.FFLennardJones:
-            iff = iforcefields.InputFFLennardJones()
+            iff = ff.iobj
             iff.store(ff)
             self.extra.append(("fflj",iff))
          elif type(ff) is eforcefields.FFDebye:
-            iff = iforcefields.InputFFDebye()
+            iff = ff.iobj
             iff.store(ff)
             self.extra.append(("ffdebye",iff))
 
 
       for s in simul.syslist:
-         isys = InputSystem()
+         isys = s.iobj
          isys.store(s)
          self.extra.append(("system",isys))
 

--- a/ipi/inputs/system.py
+++ b/ipi/inputs/system.py
@@ -127,7 +127,7 @@ class InputSystem(Input):
                                        bcomponents = self.bias.fetch(),
                                        ensemble = self.ensemble.fetch(),
                                        motion = self.motion.fetch(),
-                                       prefix = self.prefix.fetch()
-                                       )
+                                       prefix = self.prefix.fetch(),
+                                       iobj = self)
 
       return rsys


### PR DESCRIPTION
Apparently, there is a mem leakage each time simulation.store() is called.... and it is called really a lot of times... 

Apparently each time `simulation.store` is called, a new instance of `InputSystem` and `InputFFSocket` is created and this is responsible for the leakage. I did not investigate the details... 

Tested the fix with regtest and does not show any problem.

@ceriottm There is probably space for a small improvement in `simulation.store`: we could keep the name of the forcefield somewhere in the input object and we could avoid the "switch case" there. If you like the fix, I can do that. Moreover, this fix could actually be applied to every object. This should still decrease the mem usage. 