### PR TITLE
Symmetrize the dynmat before diagonalize it

### DIFF
--- a/examples/lammps/h2o-fdphonons/input.xml
+++ b/examples/lammps/h2o-fdphonons/input.xml
@@ -1,5 +1,5 @@
 <simulation mode="static" verbosity="high">
-    <output prefix="phonons">
+    <output prefix="simulation">
         <properties stride="10" filename="out">  [ step, potential ] </properties>
    </output>
    <total_steps> 5000 </total_steps>
@@ -18,8 +18,8 @@
             <vibrations mode="fd">
                 <pos_shift> 0.001 </pos_shift>
                 <energy_shift> 0.001 </energy_shift>
-                <prefix> phonons </prefix>
-                <asr> crystal </asr>
+                <prefix> simulation </prefix>
+                <asr> poly </asr>
             </vibrations>
         </motion>
     </system>

--- a/ipi/engine/motion/phonons.py
+++ b/ipi/engine/motion/phonons.py
@@ -115,8 +115,11 @@ class DynMatrixMover(Motion):
         for i in range(3 * self.beads.natoms):
             print >> outfile, ' '.join(map(str, dmatx[i]/(self.ism[i]*self.ism)))
         outfile.close()
+       
         
-        eigsys=np.linalg.eigh(dmatx)        
+          
+        #eigsys=np.linalg.eigh(dmatx)        
+        eigsys=np.linalg.eigh((dmatx+np.transpose(dmatx))/2)        
         # prints eigenvalues & eigenvectors
         outfile=open(prefix+'.eigval', 'w') 
         print >> outfile, "# Eigenvalues (atomic units)"+wstr

--- a/ipi/engine/motion/phonons.py
+++ b/ipi/engine/motion/phonons.py
@@ -117,7 +117,7 @@ class DynMatrixMover(Motion):
         outfile.close()
        
         #eigsys=np.linalg.eigh(dmatx)        
-        eigsys=np.linalg.eigh((dmatx+np.transpose(dmatx))/2)        
+        eigsys=np.linalg.eigh(dmatx)        
         # prints eigenvalues & eigenvectors
         outfile=open(prefix+'.eigval', 'w') 
         print >> outfile, "# Eigenvalues (atomic units)"+wstr

--- a/ipi/engine/motion/phonons.py
+++ b/ipi/engine/motion/phonons.py
@@ -90,8 +90,7 @@ class DynMatrixMover(Motion):
             self.phcalc.step(step)
         else:
             self.phcalc.transform()
-            rdyn = self.apply_asr(self.refdynmatrix)
-            self.refdynmatrix = (rdyn + rdyn.T)/2.0
+            self.refdynmatrix = self.apply_asr(self.refdynmatrix.copy())
             self.printall(self.prefix, self.refdynmatrix.copy())
             softexit.trigger("Dynamic matrix is calculated. Exiting simulation")
 


### PR DESCRIPTION
The 'np.linalg.eigh' algorithm is designed for symmetric (hermitian) matrix. Due to numerical inaccuracy the dynmat is not symmetric.

Example for a saddle point in a water dimer, frequencies in cm^-1:
Previous: 
 -175.2      -20.3              -11.9     -6.0           -5.5           9.8       21.2                   120.3   159.9    201.4                                                                         
With the correction  
 -176.1   - 2.5E-05      -1.4E-05   1.0E-05    1.7E-05   4.0E-05  5.2E-05               122.8   159.8    201.8

(Note that results with the correction  are the same if we use np.linalg.eig, which is for a general matrix. Although, in this case, a real output is not guaranteed and tiny imaginary part could appear. Of course np.linalg.eigh is faster )