### PR TITLE
thread-safing the depend machinery

### DIFF
--- a/ipi/utils/depend.py
+++ b/ipi/utils/depend.py
@@ -25,6 +25,7 @@ For a more detailed discussion, see the reference manual.
 
 
 import weakref
+import threading
 
 import numpy as np
 
@@ -125,10 +126,12 @@ class depend_base(object):
             dependants = []
         if dependencies is None:
             dependencies = []
+        
         self._tainted = tainted
         self._func = func
         self._name = name
         self._active = active
+        self._threadlock = threading.RLock()
 
         self.add_synchro(synchro)
 
@@ -147,10 +150,10 @@ class depend_base(object):
                 self.taint(taintme=False)
             else:
                 self.taint(taintme=tainted)
-                
+
     def hold(self):
         self._active[:] = False
-    
+
     def resume(self):
         self._active[:] = True
         if self._func is None:
@@ -215,7 +218,7 @@ class depend_base(object):
         """
 
         if not self._active: return
-        
+
         self._tainted[:] = True
         for item in self._dependants:
             if (not item()._tainted[0]):
@@ -262,20 +265,20 @@ class depend_base(object):
 
         if not self._synchro is None:
             self._synchro.manual = self._name
-            self.taint(taintme=False)            
         elif not self._func is None:
             raise NameError("Cannot set manually the value of the automatically-computed property <" + self._name + ">")
-        else:
-            self.taint(taintme=False)
+        self.taint(taintme=False)
 
     def set(self, value, manual=False):
         """Dummy setting routine."""
 
+        raise ValueError("Undefined set function for base depend class")
         pass
 
     def get(self):
         """Dummy getting routine."""
 
+        raise ValueError("Undefined get function for base depend class")
         pass
 
 
@@ -314,9 +317,10 @@ class depend_value(depend_base):
         is recalculated if tainted.
         """
 
-        if self._tainted[0]:
-            self.update_auto()
-            self.taint(taintme=False)
+        with self._threadlock:
+            if self._tainted[0]:
+                self.update_auto()
+                self.taint(taintme=False)
 
         return self._value
 
@@ -333,10 +337,11 @@ class depend_value(depend_base):
         manually updated.
         """
 
-        self._value = value
-        self.taint(taintme=False)
-        if manual:
-            self.update_man()
+        with self._threadlock:
+            self._value = value
+            #self.taint(taintme=False)
+            if manual:
+                self.update_man()
 
     def __set__(self, instance, value):
         """Overwrites standard set function."""
@@ -539,9 +544,10 @@ class depend_array(np.ndarray, depend_base):
            index: A slice variable giving the appropriate slice to be read.
         """
 
-        if self._tainted[0]:
-            self.update_auto()
-            self.taint(taintme=False)
+        with self._threadlock:
+            if self._tainted[0]:
+                self.update_auto()
+                self.taint(taintme=False)
 
         if self.__scalarindex(index, self.ndim):
             return depstrip(self)[index]
@@ -565,9 +571,10 @@ class depend_array(np.ndarray, depend_base):
         # It is worth duplicating this code that is also used in __getitem__ as this
         # is called most of the time, and we avoid creating a load of copies pointing to the same depend_array
 
-        if self._tainted[0]:
-            self.update_auto()
-            self.taint(taintme=False)
+        with self._threadlock:
+            if self._tainted[0]:
+                self.update_auto()
+                self.taint(taintme=False)
 
         return self
 
@@ -585,14 +592,15 @@ class depend_array(np.ndarray, depend_base):
               manually. True by default.
         """
 
-        self.taint(taintme=False)
-        if manual:
-            self.view(np.ndarray)[index] = value
-            self.update_man()
-        elif index == slice(None, None, None):
-            self._bval[index] = value
-        else:
-            raise IndexError("Automatically computed arrays should span the whole parent")
+        with self._threadlock:
+            if manual:
+                self.view(np.ndarray)[index] = value
+                self.update_man()
+            elif index == slice(None, None, None):
+                self._bval[index] = value
+                self.taint(taintme=False)        
+            else:
+                raise IndexError("Automatically computed arrays should span the whole parent")
 
     def __setslice__(self, i, j, value):
         """Overwrites standard set function."""
@@ -752,7 +760,7 @@ def dcopy(dfrom, dto):
     if hasattr(dfrom, "_bval"):
         dto._bval = dfrom._bval
 
-def depraise(exception): 
+def depraise(exception):
     raise exception
 
 
@@ -806,7 +814,7 @@ def dd(dobj):
     if not issubclass(dobj.__class__, dobject):
         raise ValueError("Cannot access a ddirect view of an object which is not a subclass of dobject")
     return dobj._direct
-    
+
 class ddirect(object):
     """Gives a "view" of a depend object where one can directly access its
     depend_base members."""

--- a/ipi_tests/utils/test_depend.py
+++ b/ipi_tests/utils/test_depend.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python2
+from ipi.utils.depend import *
+import numpy as np
+import threading
+import time
+
+class A(dobject):
+    def __init__(self):
+        
+        dself = dd(self)
+        
+        dself.scalar = depend_value(name="a_scalar", value=1)
+        dself.vector = depend_array(name="a_vector", value=np.zeros(10))
+        
+        dself.dscalar = depend_value(name="d_scalar", func=self.get_scalar, dependencies=[dself.scalar])
+        dself.dvector = depend_value(name="d_vector", func=self.get_vector, dependencies=[dself.dscalar, self.vector])
+        
+    def get_scalar(self):
+        return self.scalar*2
+        
+    def get_vector(self):
+        return self.vector*self.dscalar
+
+class B(dobject):
+    def __init__(self):
+        
+        dself = dd(self)
+        
+        dself.scalar = depend_value(name="b_scalar", value=1)
+        dself.vector = depend_array(name="b_vector", value=np.zeros(10))
+                
+    def bind(self, A):
+        
+        self.A = A
+        dself = dd(self)
+        dself.dscalar = depend_value(name="db_scalar", func=self.get_scalar, dependencies=[dself.scalar, dd(A).dscalar])
+        dself.dvector = depend_value(name="db_vector", func=self.get_vector, dependencies=[dself.dscalar, self.vector])
+
+        
+    def get_scalar(self):
+        return self.scalar - self.A.scalar
+        
+    def get_vector(self):
+        return self.vector*self.dscalar
+    
+myA=A()
+
+mas=5
+mav=0.3
+mbs=2
+mbv=3
+
+myA.scalar=mas
+myA.vector[:]=mav
+
+myB = B()
+myB.scalar = mbs
+myB.vector[:]= mbv
+myB.bind(myA)
+
+def threadA(Aobj):
+    for i in xrange(10000):        
+        Aobj.scalar=np.sqrt(i)
+        time.sleep(0.0001)
+
+def threadB(Aobj,Bobj):
+    for i in xrange(10000):
+        Aobj.scalar=i
+        time.sleep(0.0001)
+        Bobj.scalar=4+i
+        Bobj.vector=np.sqrt(i)
+        print Bobj.dvector[0]
+
+
+# myB.dvector should always contain B.vector*B.scalar- A.scalar
+print myB.dvector -mbv * (mbs - mas)
+
+#now try with threads
+ta = threading.Thread(target=threadA, name="TA", kwargs={"Aobj":myA})
+ta.daemon=True
+tb = threading.Thread(target=threadB, name="TB", kwargs={"Bobj":myB, "Aobj":myA})
+tb.daemon=True
+ta.start()
+tb.start()
+ta.join()
+tb.join()
+
+print myB.dvector - myB.vector * (myB.scalar-myA.scalar)


### PR DESCRIPTION
depend chains were susceptible to threads accessing them simultaneously. added threadlocks to prevent that