### PR TITLE
update the path in the Makefile

### DIFF
--- a/examples/lammps/Makefile
+++ b/examples/lammps/Makefile
@@ -38,8 +38,8 @@ h2o-piglet_8:
         $(call run_lammps,4,in.water) \
 	wait
 
-h2o-pimd:
-	cd h2o-pimd; $(IPI) input.xml & sleep 5; \
+h2o-pimd.1:
+	cd h2o-pimd.1; $(IPI) input.xml & sleep 5; \
         $(call run_lammps,4,in.water) \
 	wait
 


### PR DESCRIPTION
There is the wrong path in the command h2o-pimd.

The options in the Makefile should be updated according to the actual structure of the directory.